### PR TITLE
Dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-api",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "An API tool that extends expressJS to add validation and built-in controller CRUD, along with built-in firebase and AWS data, logging, and authentication services.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-api",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "An API tool that extends expressJS to add validation and built-in controller CRUD, along with built-in firebase and AWS data, logging, and authentication services.",
   "main": "src/index.js",
   "scripts": {

--- a/src/controllerBase.js
+++ b/src/controllerBase.js
@@ -47,16 +47,16 @@ class ControllerBase {
         this.basicCRUD(options)
 
         if (!options.noMetaData) {
-            this.router.get('/my', (req, res) => handleRoute(req, res, async (req) =>
+            this.router.get('/my/', (req, res) => handleRoute(req, res, async (req) =>
                 await this.getMyDocuments(req.user)
             ))
 
-            this.router.get('/recent', (req, res) => handleRoute(req, res, async (req) =>
+            this.router.get('/recent/', (req, res) => handleRoute(req, res, async (req) =>
                 await this.getRecentDocuments(req.params.count, req.user, options.isPublicGet)
             ))
         }
 
-        this.router.get('/includeInactive', (req, res) => handleRoute(req, res, async (req) =>
+        this.router.get('/includeInactive/', (req, res) => handleRoute(req, res, async (req) =>
             await this.getAllDocuments(req.user)
         ))
 

--- a/src/controllerBase.js
+++ b/src/controllerBase.js
@@ -24,7 +24,7 @@ class ControllerBase {
             await this.createDocument(req.body, req.user)
         ))
 
-        this.router.get('/:id', (req, res) => handleRoute(req, res, async (req) =>
+        this.router.get('/id/:id', (req, res) => handleRoute(req, res, async (req) =>
             await this.getDocumentById(req.params.id, req.user, options.isPublicGet)
         ))
 


### PR DESCRIPTION
21 - Added /id/ to handle an unexpected issue with API endpoint collisions - calls to "/my" and "/recent" etc were being interpreted as calls to retrieve objects with IDs of "my" and "recent"